### PR TITLE
Potential fix for code scanning alert no. 2: Virtual call in constructor or destructor

### DIFF
--- a/src/libLogica/Blocks/FlipFlopLevelTriggeredDType.cs
+++ b/src/libLogica/Blocks/FlipFlopLevelTriggeredDType.cs
@@ -34,10 +34,15 @@ public class FlipFlopLevelTriggeredDType : LogicElement
 
         Q.Connect(_rs.Q);
         NQ.Connect(_rs.NQ);
-        Update();
+        PerformUpdate();
     }
 
     public override void Update()
+    {
+        PerformUpdate();
+    }
+
+    private void PerformUpdate()
     {
         _not.Update();
         _and1.Update();

--- a/src/libLogica/Blocks/FlipFlopRS.cs
+++ b/src/libLogica/Blocks/FlipFlopRS.cs
@@ -33,12 +33,17 @@ public class FlipFlopRS : LogicElement
         // R S Q NQ
         // 0 0 0 1
         R.Value = true;
-        Update();
+        _InitializeState();
         R.Value = false;
-        Update();
+        _InitializeState();
     }
 
     public override void Update()
+    {
+        _InitializeState();
+    }
+
+    private void _InitializeState()
     {
         // Order is important, unit tests will fail if swapped
         _nor2.Update();

--- a/src/libLogica/Blocks/FlipFlopRS.cs
+++ b/src/libLogica/Blocks/FlipFlopRS.cs
@@ -33,17 +33,17 @@ public class FlipFlopRS : LogicElement
         // R S Q NQ
         // 0 0 0 1
         R.Value = true;
-        _InitializeState();
+        PerformUpdate();
         R.Value = false;
-        _InitializeState();
+        PerformUpdate();
     }
 
     public override void Update()
     {
-        _InitializeState();
+        PerformUpdate();
     }
 
-    private void _InitializeState()
+    private void PerformUpdate()
     {
         // Order is important, unit tests will fail if swapped
         _nor2.Update();


### PR DESCRIPTION
Potential fix for [https://github.com/grahame-student/logica/security/code-scanning/2](https://github.com/grahame-student/logica/security/code-scanning/2)

To fix the issue, we need to avoid calling the virtual `Update()` method directly from the constructor. Instead, we can refactor the code to use a private or non-virtual method within the constructor. This private method will encapsulate the logic currently in `Update()` and ensure that no overridden behavior is invoked during object construction. The `Update()` method will then delegate to this private method, preserving the existing functionality.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
